### PR TITLE
Adding oss code of conduct and GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Explain how THIS_SOFTWARE is not working as expected.
+labels:
+  - 'Type: Bug'
+  - 'Status: Untriaged'
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+# Describe the problem
+<!--- Briefly describe the issue and the expected behavior. -->
+<!--- Also, please be aware of our [Code of Conduct](https://www.chef.io/code-of-conduct/). -->
+
+## Software Version
+<!--- Tell us which version of THIS_SOFTWARE and the Operating System you are using. -->
+
+## Replication Case
+<!--- Tell us what steps to take to replicate your problem. See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) -->
+<!--- for information on how to create a good replication case. -->
+
+## Stacktrace
+<!--- If there are related error messages or stacktraces, please include the output in the details section and code block below. Feel free to copy and paste the details section for multiple output examples. Or if there is already a Gist with the output, include a link to it. -->
+<details><summary> <!-- a title/summary of this content --> </summary>
+```
+```
+</details>
+
+## Possible Solution
+<!--- If you already have ideas about how to solve the issue, add them here. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Request new functionality for THIS_SOFTWARE
+labels: 'Triage: Feature Request'
+---
+
+<!--- Provide a general summary of the requested feature in the Title above. -->
+<!--- Also, please be aware of our [Code of Conduct](https://www.chef.io/code-of-conduct/). -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+<!--- Why is this change important to you? How would you use it? -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -1,0 +1,31 @@
+---
+name: Project Membership Request
+about: Request membership in PROJECT_NAME
+title: 'REQUEST: New membership for <your-GH-handle>'
+labels: 
+assignees: ''
+
+---
+
+### GitHub Username
+e.g. (at)example_user
+
+### Project you are requesting membership in
+e.g. chef/chef
+
+### Requirements
+- [ ] I have reviewed [the community membership guidelines](https://github.com/chef/chef-oss-practices/project-membership.md)
+- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
+- [ ] I have joined the project's mailing list, e.g [Chef's](https://discourse.chef.io) or [Habitat's](https://forums.habitat.sh/)
+- [ ] I am actively contributing to 1 or more Chef Software Inc. projects
+- [ ] I have two sponsors that meet the sponsor requirements listed in [the community membership guidelines](https://github.com/chef/chef-oss-practices/project-membership.md)
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of contributions to the project
+- PRs reviewed / authored
+- Issues responded to
+- Questions answered in GitHub/Mailing List/StackOverflow 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Please refer to the Chef Community Code of Conduct at https://www.chef.io/code-of-conduct/


### PR DESCRIPTION
Adds code of conduct and GH issue templates from https://github.com/chef/oss_project_boilerplate

Signed-off-by: Will Fisher <wfisher@chef.io>