### PR TITLE
Fix version handling when building hab pkgs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -6,6 +6,14 @@ pipelines:
       description: Run pull request verification tests (spec/lint)
   - habitat/build
 
+promote:
+  channels:
+    - unstable
+    - stable
+  actions:
+    - built_in:promote_habitat_packages
+    - built_in:notify_chefio_slack_channels
+
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch
   delete_branch_on_merge: true

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,8 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
+project:
+  alias: gatherlog-reporter
+
 pipelines:
   - verify:
       public: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gatherlogs_reporter (1.2.2)
+    gatherlogs_reporter (1.2.5)
       clamp (~> 1.3)
       mixlib-shellout (~> 2.4)
       paint (~> 2.0)

--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gatherlogs_service (1.2.2)
+    gatherlogs_service (1.2.5)
       mixlib-shellout (~> 2.4)
       puma
       sinatra (~> 2.0)

--- a/service/gatherlogs_service.gemspec
+++ b/service/gatherlogs_service.gemspec
@@ -1,9 +1,15 @@
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+def read_version(file)
+  File.read(file) if File.exist?(file)
+end
+
+gem_version = read_version('../VERSION') || read_version('VERSION')
+
 Gem::Specification.new do |spec|
   spec.name          = 'gatherlogs_service'
-  spec.version       = File.exist?('../VERSION') ? File.read('../VERSION') : File.read('VERSION')
+  spec.version       = gem_version
   spec.authors       = ['Will Fisher']
   spec.email         = ['wfisher@chef.io']
   spec.license       = 'Apache-2.0'

--- a/service/gatherlogs_service.gemspec
+++ b/service/gatherlogs_service.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'gatherlogs_service'
-  spec.version       = File.read('../VERSION')
+  spec.version       = File.exist?('../VERSION') ? File.read('../VERSION') : File.read('VERSION')
   spec.authors       = ['Will Fisher']
   spec.email         = ['wfisher@chef.io']
   spec.license       = 'Apache-2.0'


### PR DESCRIPTION
When the hab pkg is being built version files from the root are copied to the root of the service build directory.  This will attempt to figure out the correct version file to load for the gemspec.