### PR TITLE
Fix building the hab pkg

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
   Max: 35
   Exclude: 
     - spec/**/*.rb
+    - gatherlogs_reporter.gemspec
 
 Layout/IndentFirstHashElement:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gatherlogs_reporter (1.2.12)
+    gatherlogs_reporter (2.0.0)
       clamp (~> 1.3)
       inspec-core (= 4.12.0)
       mixlib-shellout (~> 2.4)

--- a/bin/gl-report
+++ b/bin/gl-report
@@ -8,8 +8,7 @@
 libdir = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'rubygems'
-require 'bundler/setup'
+require 'bundler'
 require 'gatherlogs'
 require 'gatherlogs/cli'
 

--- a/gatherlogs_reporter.gemspec
+++ b/gatherlogs_reporter.gemspec
@@ -26,9 +26,11 @@ Gem::Specification.new do |spec|
                    Gemfile Gemfile.lock] + Dir.glob(
                      '{bin,lib,etc,profiles,completions}/**/*', File::FNM_DOTMATCH
                    ).reject { |f| File.directory?(f) || f.match?('inspec.lock') }
+
   if ENV['BUILD_GEM']
     spec.bindir        = 'bin'
-    spec.executables   = %w[gatherlogs_report check_logs]
+    scripts            = Dir.glob('bin/*', File::FNM_DOTMATCH)
+    spec.executables   = scripts.map { |f| File.basename(f) }.reject { |f| f.match?("check_log") }
   end
   spec.require_paths = ['lib']
 

--- a/habitat-packages/cli/plan.sh
+++ b/habitat-packages/cli/plan.sh
@@ -13,6 +13,7 @@ pkg_deps=(
   core/bash
   core/findutils
   core/git
+  core/coreutils
 )
 
 pkg_build_deps=(
@@ -51,6 +52,7 @@ do_unpack() {
 do_build() {
   pushd "$HAB_CACHE_SRC_PATH/$pkg_dirname/"
     build_line "gem build $pkg_name.gemspec ${GEM_HOME}"
+    fix_interpreter "bin/*" core/coreutils bin/env
 
     gem build ${pkg_name}.gemspec
   popd
@@ -62,9 +64,7 @@ do_install() {
     gem install ${pkg_name}-*.gem --no-document
   popd
 
-  wrap_bin 'gatherlogs_report'
-  # old bin name, kept for now for backwards compatability.
-  wrap_bin 'check_logs'
+  wrap_bin 'gatherlog'
 }
 
 # Need to wrap the gatherlogs binary to ensure GEM_HOME/GEM_PATH is correct
@@ -80,7 +80,7 @@ set -e
 source $pkg_prefix/RUNTIME_ENVIRONMENT
 export GEM_PATH GEM_HOME PATH
 
-exec $(pkg_path_for core/ruby)/bin/ruby $real_bin \$@
+exec $real_bin \$@
 EOF
   chmod -v 755 "$bin"
 }


### PR DESCRIPTION
Because of the way the cli scripts were revamped the habitat packages
were no longer being build correctly to replace the shebang

Signed-off-by: Will Fisher <wfisher@chef.io>
