### PR TITLE
Remove bundler setup require

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gatherlogs_reporter (2.0.3)
+    gatherlogs_reporter (2.0.4)
       clamp (~> 1.3)
       inspec-core (= 4.12.0)
       mixlib-shellout (~> 2.4)

--- a/bin/gl-version
+++ b/bin/gl-version
@@ -6,8 +6,7 @@
 libdir = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'rubygems'
-require 'bundler/setup'
+require 'bundler'
 require 'gatherlogs'
 
 module Gatherlogs


### PR DESCRIPTION
This was causing the hab package installations to break because it
doesn't have the correct environment for the gemfile

Signed-off-by: Will Fisher <wfisher@chef.io>