### PR TITLE
Add changelog rollup expeditor configs

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,6 +9,9 @@ pipelines:
       description: Run pull request verification tests (spec/lint)
   - habitat/build
 
+changelog:
+  rollup_header: Changes not yet released to stable
+
 promote:
   channels:
     - unstable

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -14,6 +14,7 @@ promote:
     - unstable
     - stable
   actions:
+    - built_in:rollover_changelog
     - built_in:promote_habitat_packages
     - built_in:notify_chefio_slack_channels
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Bump rspec from 3.8.0 to 3.9.0 [#140](https://github.com/chef/gatherlogs-reporter/pull/140) ([dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 <!-- latest_release -->
 
+<!-- release_rollup -->
+<!-- release_rollup -->
+
+<!-- latest_stable_release -->
+<!-- latest_stable_release -->
+
 ## [v2.0.10](https://github.com/chef/gatherlogs-reporter/tree/v2.0.10) (2019-10-21)
 
 #### Merged Pull Requests


### PR DESCRIPTION
Seeing if we can get the changelog setup to have the rollup changes happen similar to chef and chef-dk

Since this involves expeditor changes add them for a request to review as well.